### PR TITLE
Create structs for Optional types so we can pass them to P/Invokes

### DIFF
--- a/azure-pipelines.yaml
+++ b/azure-pipelines.yaml
@@ -6,6 +6,37 @@ trigger:
 stages:
   - stage: Build
     jobs:
+    - job: DebugBuildAndTest
+      displayName: 'Debug build and test Xamarin.SwiftUI'
+      pool:
+        vmImage: macOS-latest
+      steps:
+      - task: MSBuild@1
+        displayName: 'msbuild build.proj'
+        inputs:
+          solution: build.proj
+          configuration: Debug
+          msbuildArguments: /restore
+      - task: DotNetCoreCLI@2
+        displayName: 'dotnet test SwiftUI.Tests'
+        inputs:
+          command: 'test'
+          arguments: '--configuration Debug'
+          projects: 'tests/SwiftUI.Tests/SwiftUI.Tests.csproj'
+          testRunTitle: 'SwiftUI.Tests'
+      - task: DotNetCoreCLI@2
+        displayName: 'dotnet build SwiftUI.Tests.FSharp'
+        inputs:
+          command: 'build'
+          arguments: '--configuration Debug'
+          projects: 'tests/SwiftUI.Tests.FSharp/SwiftUI.Tests.FSharp.fsproj'
+      - task: DotNetCoreCLI@2
+        displayName: 'dotnet test SwiftUI.Tests.FSharp'
+        inputs:
+          command: 'test'
+          arguments: '--configuration Debug'
+          projects: 'tests/SwiftUI.Tests.FSharp/SwiftUI.Tests.FSharp.fsproj'
+          testRunTitle: 'SwiftUI.Tests.FSharp'
     - job: BuildSwiftUIGlueAndNuGets
       displayName: 'Build, test, and package Xamarin.SwiftUI'
       pool:

--- a/src/SwiftUI/Swift/Interop/SwiftType.cs
+++ b/src/SwiftUI/Swift/Interop/SwiftType.cs
@@ -171,6 +171,12 @@ namespace Swift.Interop
 
 			// Assert assumed invariants..
 			Debug.Assert (!ValueWitnessTable->IsNonBitwiseTakable, $"expected bitwise movable: {managedType?.Name}");
+			SanityCheck (managedType);
+		}
+
+		[Conditional ("DEBUG")]
+		internal void SanityCheck (Type? managedType)
+		{
 			if (managedType is null)
 				return;
 			checked {

--- a/src/SwiftUI/Swift/Interop/ValueWitnessTable.cs
+++ b/src/SwiftUI/Swift/Interop/ValueWitnessTable.cs
@@ -3,16 +3,19 @@ using System.Runtime.InteropServices;
 
 namespace Swift.Interop
 {
+	// https://github.com/apple/swift/blob/a021e6ca020e667ce4bc8ee174e2de1cc0d9be73/include/swift/ABI/MetadataValues.h#L117
 	[Flags]
 	public enum ValueWitnessFlags
 	{
 		AlignmentMask = 0x0000FFFF,
 		IsNonPOD = 0x00010000,
 		IsNonInline = 0x00020000,
-		HasExtraInhabitants = 0x00040000,
+		// unused 0x00040000,
 		HasSpareBits = 0x00080000,
 		IsNonBitwiseTakable = 0x00100000,
-		HasEnumWitnesses = 0x00200000
+		HasEnumWitnesses = 0x00200000,
+		Incomplete = 0x00400000,
+		// unused 0xFF800000,
 	}
 
 	/// <summary>
@@ -86,10 +89,17 @@ namespace Swift.Interop
 
 		public ValueWitnessFlags Flags;
 
+		///   UINT_TYPE extraInhabitantCount;
+		///
+		/// The number of extra inhabitants in the type.
+		public uint ExtraInhabitantCount;
+
 		public int Alignment => (int)((Flags & ValueWitnessFlags.AlignmentMask) + 1);
 
 		public bool IsNonPOD => Flags.HasFlag (ValueWitnessFlags.IsNonPOD);
 
 		public bool IsNonBitwiseTakable => Flags.HasFlag (ValueWitnessFlags.IsNonBitwiseTakable);
+
+		public bool HasExtraInhabitants => ExtraInhabitantCount != 0;
 	}
 }

--- a/src/SwiftUI/Swift/Optional.cs
+++ b/src/SwiftUI/Swift/Optional.cs
@@ -1,0 +1,130 @@
+using System;
+using System.Diagnostics;
+using System.Runtime.InteropServices;
+
+using Swift.Interop;
+
+namespace Swift
+{
+	static unsafe class Optional
+	{
+		const int EmptyCases = 1;
+
+		public enum Tag
+		{
+			Some = 0,
+			None = 1
+		}
+
+		public static void StoreTag (this SwiftType wrappedType, void* ptr, Tag tag)
+			=> wrappedType.StoreEnumTagSinglePayload (ptr, (int)tag, EmptyCases);
+
+		internal static SwiftHandle Wrap (void* src, SwiftType optionalType, SwiftType wrappedType)
+		{
+			var data = new byte [optionalType.NativeDataSize];
+			fixed (void* dest = &data [0]) {
+				var tag = Tag.None;
+				if (src != null) {
+					tag = Tag.Some;
+					wrappedType.Transfer (dest, src, TransferFuncType.InitWithCopy);
+				}
+				wrappedType.StoreTag (dest, tag);
+			}
+			return new SwiftHandle (data, optionalType, destroyOnDispose: true);
+		}
+
+		/// <summary>
+		/// Represents a <c>Swift.Optional</c> value of <typeparamref name="T"/>
+		///  where the binary representation of type <typeparamref name="T"/>
+		///  contains an extra inhabitant and therefore the native size of
+		///  <c>Optional&lt;<typeparamref name="T"/>&gt;</c> is the same as
+		///  the native size of <typeparamref name="T"/>.
+		/// </summary>
+		[StructLayout (LayoutKind.Sequential)]
+		public readonly struct Packed<T> : ISwiftBlittableStruct<Packed<T>>
+			where T : unmanaged
+		{
+			readonly T value;
+
+			// FIXME: Account for the case where T might have nullable type arguments?
+			static SwiftType UnderlyingSwiftType => SwiftType.Of (typeof (T))!;
+
+			public static Packed<T> None {
+				get {
+					var packed = default (Packed<T>);
+					UnderlyingSwiftType.StoreTag (&packed, Tag.None);
+					return packed;
+				}
+			}
+
+			public static Packed<T> Some (T value)
+			{
+				var packed = new Packed<T> (value);
+				UnderlyingSwiftType.StoreTag (&packed, Tag.Some);
+				return packed;
+			}
+
+			Packed (T value) => this.value = value;
+
+			#if DEBUG
+			static Packed ()
+			{
+				unsafe {
+					Debug.Assert (UnderlyingSwiftType.ValueWitnessTable->HasExtraInhabitants,
+						$"Type {nameof (T)} has no extra inhabitants; use {nameof (Unpacked<T>)} instead");
+					Debug.Assert ((int)SwiftType.Of (typeof (T), new Nullability (true))!.ValueWitnessTable->Size == Marshal.SizeOf<T> ());
+				}
+			}
+			#endif
+		}
+
+		/// <summary>
+		/// Represents a <c>Swift.Optional</c> value of <typeparamref name="T"/>
+		///  where the binary representation of type <typeparamref name="T"/>
+		///  contains no extra inhabitants, and therefore extra bits are added
+		///  for the tag.
+		/// </summary>
+		[StructLayout (LayoutKind.Sequential)]
+		public readonly struct Unpacked<T> : ISwiftBlittableStruct<Unpacked<T>>
+			where T : unmanaged
+		{
+			readonly T value;
+			readonly byte extraBits;
+
+			// FIXME: Account for the case where T might have nullable type arguments?
+			static SwiftType UnderlyingSwiftType => SwiftType.Of (typeof (T))!;
+
+			public static Unpacked<T> None {
+				get {
+					var unpacked = default (Unpacked<T>);
+					UnderlyingSwiftType.StoreTag (&unpacked, Tag.None);
+					return unpacked;
+				}
+			}
+
+			public static Unpacked<T> Some (T value)
+			{
+				var unpacked = new Unpacked<T> (value);
+				UnderlyingSwiftType.StoreTag (&unpacked, Tag.Some);
+				return unpacked;
+			}
+
+			Unpacked (T value)
+			{
+				this.value = value;
+				this.extraBits = 0;
+			}
+
+			#if DEBUG
+			static Unpacked ()
+			{
+				unsafe {
+					Debug.Assert (!UnderlyingSwiftType.ValueWitnessTable->HasExtraInhabitants,
+						$"Type {nameof (T)} has extra inhabitants; use {nameof (Packed<T>)} instead");
+					Debug.Assert ((int)SwiftType.Of (typeof (T), new Nullability (true))!.ValueWitnessTable->Size == Marshal.SizeOf<T> () + 1); // FIXME
+				}
+			}
+			#endif
+		}
+	}
+}

--- a/src/SwiftUI/Swift/String.cs
+++ b/src/SwiftUI/Swift/String.cs
@@ -8,6 +8,7 @@ using Swift.Interop;
 namespace Swift
 {
 	[StructLayout (LayoutKind.Sequential)]
+	[SwiftImport (SwiftCoreLib.Path, "SS")]
 	readonly unsafe struct String : ISwiftBlittableStruct<String>, IDisposable
 	{
 		public static String Empty => default;

--- a/src/SwiftUI/Swift/SwiftCoreLib.cs
+++ b/src/SwiftUI/Swift/SwiftCoreLib.cs
@@ -21,7 +21,7 @@ namespace Swift
 			if (type == typeof (IntPtr))
 				return new SwiftType (Lib, "SV");
 			return Type.GetTypeCode (type) switch {
-				TypeCode.String => new SwiftType (Lib, "SS", typeof (Swift.String)),
+				TypeCode.String => SwiftType.Of (typeof (Swift.String)),
 				TypeCode.Byte => new SwiftType (Lib, "Swift", "UInt8", SwiftTypeCode.Struct),
 				TypeCode.SByte => new SwiftType (Lib, "Swift", "Int8", SwiftTypeCode.Struct),
 				TypeCode.Int16 => new SwiftType (Lib, "Swift", "Int16", SwiftTypeCode.Struct, typeof (Int16)),

--- a/tests/SwiftUI.Tests/SwiftUI.Tests.csproj
+++ b/tests/SwiftUI.Tests/SwiftUI.Tests.csproj
@@ -17,6 +17,7 @@
 			<IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
 			<PrivateAssets>all</PrivateAssets>
 		</PackageReference>
+		<PackageReference Include="Xunit.SkippableFact" Version="1.4.8" />
 	</ItemGroup>
 
 	<ItemGroup>

--- a/tests/SwiftUI.Tests/TestFixture.cs
+++ b/tests/SwiftUI.Tests/TestFixture.cs
@@ -1,14 +1,8 @@
 using System;
 namespace SwiftUI.Tests
 {
-	public class TestFixture : IDisposable
+	public class TestFixture
 	{
-		ThrowingTraceListener? throwForFailedAsserts = new ThrowingTraceListener ();
-
-		public void Dispose ()
-		{
-			throwForFailedAsserts?.Dispose ();
-			throwForFailedAsserts = null;
-		}
+		internal static readonly ThrowingTraceListener? ThrowForFailedAsserts = new ThrowingTraceListener ();
 	}
 }

--- a/tests/SwiftUI.Tests/TypeTests.cs
+++ b/tests/SwiftUI.Tests/TypeTests.cs
@@ -48,20 +48,21 @@ namespace SwiftUI.Tests
 			}
 		}
 
-		[Theory]
-		[InlineData (typeof (Swift.String))]
-		[InlineData (typeof (IntPtr))]
-		public void PackedOptionalTypes (Type wrappedType)
-			=> typeof (Optional.Packed<>).MakeGenericType (wrappedType).TypeInitializer!.Invoke (null, null);
-
-		[Theory]
-		[InlineData (typeof (byte))]
-		[InlineData (typeof (sbyte))]
-		[InlineData (typeof (int))]
-		[InlineData (typeof (long))]
-		[InlineData (typeof (double))]
-		[InlineData (typeof (float))]
-		public void UnpackedOptionalTypes (Type wrappedType)
-			=> typeof (Optional.Unpacked<>).MakeGenericType (wrappedType).TypeInitializer!.Invoke (null, null);
+		[SkippableTheory]
+		[InlineData (typeof (Optional.Packed<>), typeof (Swift.String))]
+		[InlineData (typeof (Optional.Packed<>), typeof (IntPtr))]
+		[InlineData (typeof (Optional.Unpacked<>), typeof (byte))]
+		[InlineData (typeof (Optional.Unpacked<>), typeof (sbyte))]
+		[InlineData (typeof (Optional.Unpacked<>), typeof (int))]
+		[InlineData (typeof (Optional.Unpacked<>), typeof (long))]
+		[InlineData (typeof (Optional.Unpacked<>), typeof (double))]
+		[InlineData (typeof (Optional.Unpacked<>), typeof (float))]
+		public void OptionalTypes (Type optionalType, Type wrappedType)
+		{
+			// static constructor has asserts, but it is only included for DEBUG builds..
+			var cctor = optionalType.MakeGenericType (wrappedType).TypeInitializer;
+			Skip.If (cctor is null, "Asserts only compiled in debug builds");
+			cctor!.Invoke (null, null);
+		}
 	}
 }

--- a/tests/SwiftUI.Tests/TypeTests.cs
+++ b/tests/SwiftUI.Tests/TypeTests.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Linq;
+using System.Reflection;
 using System.Diagnostics;
 
 using Xunit;
@@ -46,5 +47,21 @@ namespace SwiftUI.Tests
 				Assert.Equal ("Optional", gargs [0].Metadata->TypeDescriptor->Name);
 			}
 		}
+
+		[Theory]
+		[InlineData (typeof (Swift.String))]
+		[InlineData (typeof (IntPtr))]
+		public void PackedOptionalTypes (Type wrappedType)
+			=> typeof (Optional.Packed<>).MakeGenericType (wrappedType).TypeInitializer!.Invoke (null, null);
+
+		[Theory]
+		[InlineData (typeof (byte))]
+		[InlineData (typeof (sbyte))]
+		[InlineData (typeof (int))]
+		[InlineData (typeof (long))]
+		[InlineData (typeof (double))]
+		[InlineData (typeof (float))]
+		public void UnpackedOptionalTypes (Type wrappedType)
+			=> typeof (Optional.Unpacked<>).MakeGenericType (wrappedType).TypeInitializer!.Invoke (null, null);
 	}
 }


### PR DESCRIPTION
These are largely untested; they may need some minor adjustments for alignment/padding.

See https://github.com/apple/swift/blob/master/docs/ABI/TypeLayout.rst#single-payload-enums for discussion of why we need 2 different structs to represent `Optional`. Due to this complexity, I've opted to keep this internal for now.