### PR TITLE
Looks like it was the SharedProject's namespace name length which was…

### DIFF
--- a/XamMacSwiftUITest.FSharp/XamMacSwiftUITest.FSharp.fsproj
+++ b/XamMacSwiftUITest.FSharp/XamMacSwiftUITest.FSharp.fsproj
@@ -58,7 +58,7 @@
     <Reference Include="mscorlib" />
     <Reference Include="System.Numerics" />
     <Reference Include="FSharp.Core">
-      <HintPath>..\packages\FSharp.Core.4.7.1\lib\netstandard2.0\FSharp.Core.dll</HintPath>
+      <HintPath>..\packages\FSharp.Core.4.7.2\lib\netstandard2.0\FSharp.Core.dll</HintPath>
     </Reference>
   </ItemGroup>
   <ItemGroup>
@@ -79,7 +79,5 @@
     </ProjectReference>
   </ItemGroup>
   <Target Name="VSTest" />
-  <Import
-    Project="$(MSBuildExtensionsPath)\Xamarin\Mac\Xamarin.Mac.FSharp.targets"
-    Condition="Exists('$(MSBuildExtensionsPath)\Xamarin\Mac\Xamarin.Mac.FSharp.targets')" />
+  <Import Project="$(MSBuildExtensionsPath)\Xamarin\Mac\Xamarin.Mac.FSharp.targets" Condition="Exists('$(MSBuildExtensionsPath)\Xamarin\Mac\Xamarin.Mac.FSharp.targets')" />
 </Project>

--- a/XamMacSwiftUITest.FSharp/packages.config
+++ b/XamMacSwiftUITest.FSharp/packages.config
@@ -1,4 +1,4 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="FSharp.Core" version="4.7.1" targetFramework="xamarinmac20" />
+  <package id="FSharp.Core" version="4.7.2" targetFramework="xamarinmac20" />
 </packages>

--- a/XamMacSwiftUITest/AppDelegate.cs
+++ b/XamMacSwiftUITest/AppDelegate.cs
@@ -5,6 +5,7 @@ using Foundation;
 using CoreGraphics;
 
 using SwiftUI;
+using SwiftUITestShared;
 
 namespace XamMacSwiftUITest
 {
@@ -31,5 +32,5 @@ namespace XamMacSwiftUITest
 
 			window.MakeKeyAndOrderFront (this);
 		}
-    }
+	}
 }

--- a/XamMacSwiftUITest/AppDelegate.cs
+++ b/XamMacSwiftUITest/AppDelegate.cs
@@ -32,26 +32,4 @@ namespace XamMacSwiftUITest
 			window.MakeKeyAndOrderFront (this);
 		}
     }
-
-	public partial class ClickButton : View
-	{
-		State<int?> counter = new State<int?> (null);
-
-		public ModifiedBackground<Button<Text>, ModifiedBackground<Text, Color>> Body {
-			get {
-				Button<Text> button = null;
-				button = new Button<Text> (
-					() => {
-						var value = counter.Value ?? 0;
-						counter.Value = value + 1;
-					}, new Text (string.Format (counter.Value.HasValue ? "Clicked {0} times" : "Never been clicked", counter.Value))
-				);
-
-				var colour = counter.Value.HasValue ? counter.Value % 2 == 0 ? Color.Red : Color.Blue : Color.Yellow;
-				var colourText = counter.Value.HasValue ? counter.Value % 2 == 0 ? nameof (Color.Red) : nameof (Color.Blue) : nameof (Color.Yellow);
-
-				return button.Background (new Text (colourText).Background (colour));
-			}
-		}
-	}
 }

--- a/XamMacSwiftUITest/XamMacSwiftUITest.csproj
+++ b/XamMacSwiftUITest/XamMacSwiftUITest.csproj
@@ -79,7 +79,6 @@
     </ProjectReference>
   </ItemGroup>
   <Target Name="VSTest" />
-  <Import
-    Project="$(MSBuildExtensionsPath)\Xamarin\Mac\Xamarin.Mac.CSharp.targets"
-    Condition="Exists('$(MSBuildExtensionsPath)\Xamarin\Mac\Xamarin.Mac.CSharp.targets')" />
+  <Import Project="..\XamSwiftUITestShared\XamSwiftUITestShared.projitems" Label="Shared" Condition="Exists('..\XamSwiftUITestShared\XamSwiftUITestShared.projitems')" />
+  <Import Project="$(MSBuildExtensionsPath)\Xamarin\Mac\Xamarin.Mac.CSharp.targets" Condition="Exists('$(MSBuildExtensionsPath)\Xamarin\Mac\Xamarin.Mac.CSharp.targets')" />
 </Project>

--- a/XamMacSwiftUITest/XamMacSwiftUITest.csproj
+++ b/XamMacSwiftUITest/XamMacSwiftUITest.csproj
@@ -79,6 +79,8 @@
     </ProjectReference>
   </ItemGroup>
   <Target Name="VSTest" />
+  <Import
+    Project="$(MSBuildExtensionsPath)\Xamarin\Mac\Xamarin.Mac.CSharp.targets"
+    Condition="Exists('$(MSBuildExtensionsPath)\Xamarin\Mac\Xamarin.Mac.CSharp.targets')" />
   <Import Project="..\XamSwiftUITestShared\XamSwiftUITestShared.projitems" Label="Shared" Condition="Exists('..\XamSwiftUITestShared\XamSwiftUITestShared.projitems')" />
-  <Import Project="$(MSBuildExtensionsPath)\Xamarin\Mac\Xamarin.Mac.CSharp.targets" Condition="Exists('$(MSBuildExtensionsPath)\Xamarin\Mac\Xamarin.Mac.CSharp.targets')" />
 </Project>

--- a/XamSwiftUITestShared/View.cs
+++ b/XamSwiftUITestShared/View.cs
@@ -2,7 +2,7 @@
 
 using SwiftUI;
 
-namespace XamMacSwiftUITest
+namespace SwiftUITestShared
 {
 	public partial class ClickButton : View
 	{

--- a/XamSwiftUITestShared/View.cs
+++ b/XamSwiftUITestShared/View.cs
@@ -2,12 +2,27 @@
 
 using SwiftUI;
 
-namespace XamSwiftUITestShared
+namespace XamMacSwiftUITest
 {
-    public class ClickButton : View
-    {
-        State<int> counter = new State<int> (0);
-        public Button<Text> Body =>
-            new Button<Text> (() => counter.Value += 1, new Text (string.Format("Clicked {0} times", counter.Value)));
-    }
+	public partial class ClickButton : View
+	{
+		State<int?> counter = new State<int?> (null);
+
+		public ModifiedBackground<Button<Text>, ModifiedBackground<Text, Color>> Body {
+			get {
+				Button<Text> button = null;
+				button = new Button<Text> (
+					() => {
+						var value = counter.Value ?? 0;
+						counter.Value = value + 1;
+					}, new Text (string.Format (counter.Value.HasValue ? "Clicked {0} times" : "Never been clicked", counter.Value))
+				);
+
+				var colour = counter.Value.HasValue ? counter.Value % 2 == 0 ? Color.Red : Color.Blue : Color.Yellow;
+				var colourText = counter.Value.HasValue ? counter.Value % 2 == 0 ? nameof (Color.Red) : nameof (Color.Blue) : nameof (Color.Yellow);
+
+				return button.Background (new Text (colourText).Background (colour));
+			}
+		}
+	}
 }

--- a/XamiOSSwiftUITest/AppDelegate.cs
+++ b/XamiOSSwiftUITest/AppDelegate.cs
@@ -4,7 +4,7 @@ using Foundation;
 using UIKit;
 
 using SwiftUI;
-using XamMacSwiftUITest;
+using SwiftUITestShared;
 
 namespace XamiOSSwiftUITest
 {

--- a/XamiOSSwiftUITest/AppDelegate.cs
+++ b/XamiOSSwiftUITest/AppDelegate.cs
@@ -4,6 +4,7 @@ using Foundation;
 using UIKit;
 
 using SwiftUI;
+using XamMacSwiftUITest;
 
 namespace XamiOSSwiftUITest
 {
@@ -29,31 +30,4 @@ namespace XamiOSSwiftUITest
             return true;
         }
     }
-
-    public partial class ClickButton : View
-    {
-        State<int?> counter = new State<int?> (null);
-
-        // Using a Custom Asset Colour
-        const string ColourAssetName = "MyYellow";
-        Color myYellow = new Color (ColourAssetName);
-
-        public ModifiedBackground<Button<Text>, ModifiedBackground<Text, Color>> Body {
-            get {
-                Button<Text> button = null;
-                button = new Button<Text> (
-                    () => {
-                        var value = counter.Value ?? 0;
-                        counter.Value = value + 1;
-                    }, new Text (string.Format (counter.Value.HasValue ? "Clicked {0} times" : "Never been clicked", counter.Value))
-                );
-
-                var colour = counter.Value.HasValue ? counter.Value % 2 == 0 ? Color.Red : Color.Blue : myYellow;
-                var colourText = counter.Value.HasValue ? counter.Value % 2 == 0 ? nameof (Color.Red) : nameof (Color.Blue) : ColourAssetName;
-
-                return button.Background (new Text (colourText).Background (colour));
-            }
-        }
-    }
 }
-

--- a/XamiOSSwiftUITest/XamiOSSwiftUITest.csproj
+++ b/XamiOSSwiftUITest/XamiOSSwiftUITest.csproj
@@ -140,6 +140,8 @@
       </ProjectReference>
     </ItemGroup>
     <Target Name="VSTest" />
+    <Import
+      Project="$(MSBuildExtensionsPath)\Xamarin\Mac\Xamarin.iOS.CSharp.targets"
+      Condition="Exists('$(MSBuildExtensionsPath)\Xamarin\Mac\Xamarin.iOS.CSharp.targets')" />
     <Import Project="..\XamSwiftUITestShared\XamSwiftUITestShared.projitems" Label="Shared" Condition="Exists('..\XamSwiftUITestShared\XamSwiftUITestShared.projitems')" />
-    <Import Project="$(MSBuildExtensionsPath)\Xamarin\iOS\Xamarin.iOS.CSharp.targets" Condition="Exists('$(MSBuildExtensionsPath)\Xamarin\iOS\Xamarin.iOS.CSharp.targets')" />
 </Project>

--- a/XamiOSSwiftUITest/XamiOSSwiftUITest.csproj
+++ b/XamiOSSwiftUITest/XamiOSSwiftUITest.csproj
@@ -141,7 +141,7 @@
     </ItemGroup>
     <Target Name="VSTest" />
     <Import
-      Project="$(MSBuildExtensionsPath)\Xamarin\Mac\Xamarin.iOS.CSharp.targets"
-      Condition="Exists('$(MSBuildExtensionsPath)\Xamarin\Mac\Xamarin.iOS.CSharp.targets')" />
+        Project="$(MSBuildExtensionsPath)\Xamarin\iOS\Xamarin.iOS.CSharp.targets"
+        Condition="Exists('$(MSBuildExtensionsPath)\Xamarin\iOS\Xamarin.iOS.CSharp.targets')" />
     <Import Project="..\XamSwiftUITestShared\XamSwiftUITestShared.projitems" Label="Shared" Condition="Exists('..\XamSwiftUITestShared\XamSwiftUITestShared.projitems')" />
 </Project>

--- a/XamiOSSwiftUITest/XamiOSSwiftUITest.csproj
+++ b/XamiOSSwiftUITest/XamiOSSwiftUITest.csproj
@@ -140,7 +140,6 @@
       </ProjectReference>
     </ItemGroup>
     <Target Name="VSTest" />
-    <Import
-        Project="$(MSBuildExtensionsPath)\Xamarin\iOS\Xamarin.iOS.CSharp.targets"
-        Condition="Exists('$(MSBuildExtensionsPath)\Xamarin\iOS\Xamarin.iOS.CSharp.targets')" />
+    <Import Project="..\XamSwiftUITestShared\XamSwiftUITestShared.projitems" Label="Shared" Condition="Exists('..\XamSwiftUITestShared\XamSwiftUITestShared.projitems')" />
+    <Import Project="$(MSBuildExtensionsPath)\Xamarin\iOS\Xamarin.iOS.CSharp.targets" Condition="Exists('$(MSBuildExtensionsPath)\Xamarin\iOS\Xamarin.iOS.CSharp.targets')" />
 </Project>


### PR DESCRIPTION
 causing the crash. Still very odd, but it builds and runs on both iOS and Mac now.

Changed to an odd numbered name length, as a temporary workaround.

Fixes -  https://github.com/chkn/Xamarin.SwiftUI/issues/4