### PR TITLE
Bridge tuples and bool, and TupleView, VStack and friends

### DIFF
--- a/Hacking.md
+++ b/Hacking.md
@@ -11,15 +11,17 @@ Swift classes are reference counted. Swift structs may contain pointers to insta
 
 ## Calling into Swift
 
-When possible, calls to Swift functions should be made directly through P/Invoke.
+Calls to Swift functions are made through P/Invoke. The Swift calling convention is based on the C calling convention with some modifications. This means that you may be able to P/Invoke directly to a Swift API if it falls into the subset that overlaps with the C calling convention. However, if the API you wish to call does not fall into that subset, you must write a Swift glue function that _is_ callable through P/Invoke, which in turn calls the desired Swift API.
 
-### Direct P/Invoke
+### Guidelines for P/Invoke
 
-The Swift calling convention is based on the C calling convention with some modifications. This means that you may be able to P/Invoke directly to a Swift API if it falls into the subset that overlaps with the C calling convention.
+When P/Invoking, either directly to a Swift API, or to a Swift glue function, there are some things to keep in mind.
 
 #### Differences in Calling Convention
 
-- `Double?` (and `CGFloat?` on 64-bit systems) is essentially a 65-bit type. In memory, it is represented as essentially `double` followed by `byte`, however it seems the calling convention might move this all in a single register, at least on x86_64, which cannot be marshaled by P/Invoke.
+##### Optional Double
+
+`Double?` (and `CGFloat?` on 64-bit systems) is essentially a 65-bit type. In memory, it is represented as essentially `double` followed by `byte`, however it seems the calling convention might move this all in a single register, at least on x86_64, which cannot be marshaled by P/Invoke. You can pass this as two arguments: a `Double` value, and a `Bool` that indicates if the first argument is valid.
 
 #### Hidden Arguments
 

--- a/Hacking.md
+++ b/Hacking.md
@@ -11,14 +11,25 @@ Swift classes are reference counted. Swift structs may contain pointers to insta
 
 ## Calling into Swift
 
-The Swift calling convention is based on the C calling convention with some modifications. This means that you may be able to P/Invoke directly to the Swift API if it falls into the subset that overlaps with the C calling convention.
+When possible, calls to Swift functions should be made directly through P/Invoke.
 
 ### Direct P/Invoke
 
-When P/Invoking a Swift function, you must keep in mind that Swift may pass some hidden arguments.
+The Swift calling convention is based on the C calling convention with some modifications. This means that you may be able to P/Invoke directly to a Swift API if it falls into the subset that overlaps with the C calling convention.
 
-- In addition to the declared arguments in the Swift signature, Swift appends a `this` argument for instance members, followed by type metadata for each generic parameter, first for generic arguments on the declaring type, then for those on the method itself. If the generic parameter is constrained by a protocol, there is another argument for the conformance pointer following the type metadata.
-- When passing more than 1 generic parameter, the order is *important*. The order must be Generic1Pointer, Generic2Pointer, Generic1Metadata, Generic2Metadata, Generic1Protocol, Generic2Protocol
+#### Differences in Calling Convention
+
+- `Double?` (and `CGFloat?` on 64-bit systems) is essentially a 65-bit type. In memory, it is represented as essentially `double` followed by `byte`, however it seems the calling convention might move this all in a single register, at least on x86_64, which cannot be marshaled by P/Invoke.
+
+#### Hidden Arguments
+
+When P/Invoking a Swift function, you must keep in mind that Swift may pass some hidden arguments. In addition to the declared arguments in the Swift signature, Swift appends:
+
+- `this` argument for instance members
+- Type metadata for each generic parameter in declaration order, first for generic arguments on the declaring type, then for those on the method itself.
+- If the generic parameter is constrained by a protocol, there is another argument for each conformance pointer following the type metadata.
+
+When passing more than 1 generic parameter, the order is *important*. The order must be ...declared arguments, `Generic1TypeMetadata*`, `Generic2TypeMetadata*`, `Generic1ProtocolConformance*`, `Generic2ProtocolConformance*`
 
 ### Glue Function
 

--- a/Tooling.md
+++ b/Tooling.md
@@ -6,6 +6,3 @@ C# nullable reference types should be enabled, as nullable values are automatica
 
 F# Option and ValueOption are also automatically bridged as Swift Optional. For automatic bridging of F# ValueOption, you must be using a version of `FSharp.Core` newer than 4.5.2.
 
-## Body Property
-
-We should have an analyzer to ensure the View.Body property is correctly implemented.

--- a/XamMacSwiftUITest/AppDelegate.cs
+++ b/XamMacSwiftUITest/AppDelegate.cs
@@ -28,7 +28,7 @@ namespace XamMacSwiftUITest
 			};
 			window.Center ();
 
-			window.ContentView = new NSHostingView (new ClickButton ());
+			window.ContentView = new NSHostingView (new StackedView ());
 
 			window.MakeKeyAndOrderFront (this);
 		}

--- a/XamMacSwiftUITest/XamMacSwiftUITest.csproj
+++ b/XamMacSwiftUITest/XamMacSwiftUITest.csproj
@@ -13,6 +13,8 @@
     <MonoMacResourcePrefix>Resources</MonoMacResourcePrefix>
     <TargetFrameworkIdentifier>Xamarin.Mac</TargetFrameworkIdentifier>
     <AutoGenerateBindingRedirects>true</AutoGenerateBindingRedirects>
+    <LangVersion>8.0</LangVersion>
+    <Nullable>enable</Nullable>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <DebugSymbols>true</DebugSymbols>

--- a/XamSwiftUITestShared/View.cs
+++ b/XamSwiftUITestShared/View.cs
@@ -6,24 +6,26 @@ namespace SwiftUITestShared
 {
 	public partial class StackedView : View
 	{
-		public TupleView<(ClickButton, Text)> Body =>
-			new TupleView<(ClickButton, Text)> ((
-				new ClickButton (),
-				new Text ("Bottom text")
-			));
+		public VStack<TupleView<(ClickButton, Text)>> Body =>
+			new VStack<TupleView<(ClickButton, Text)>> (HorizontalAlignment.Trailing,
+				new TupleView<(ClickButton, Text)> ((
+					new ClickButton (),
+					new Text ("Right text")
+				)));
 	}
 
 	public partial class ClickButton : View
 	{
 		State<(string, bool)> state = new State<(string, bool)> (("Please click this button:", true));
-		public TupleView<(Text, Button<Text>?)> Body =>
-			new TupleView<(Text, Button<Text>?)> ((
-				new Text (state.Value.Item1),
-				state.Value.Item2 ? new Button<Text> (() => state.Value = ("Thanks!", false), new Text ("Click me!")) : null
-				));
+		public VStack<TupleView<(Text, Button<Text>?)>> Body =>
+			new VStack<TupleView<(Text, Button<Text>?)>> (HorizontalAlignment.Leading,
+				new TupleView<(Text, Button<Text>?)> ((
+					new Text (state.Value.Item1),
+					state.Value.Item2 ? new Button<Text> (() => state.Value = ("Thanks!", false), new Text ("Click me!")) : null
+				)));
 	}
 
-	/*
+	/*	
 	public partial class ClickButton : View
 	{
 		State<int?> counter = new State<int?> (null);
@@ -48,3 +50,4 @@ namespace SwiftUITestShared
 	*/
 
 }
+ 

--- a/XamSwiftUITestShared/View.cs
+++ b/XamSwiftUITestShared/View.cs
@@ -4,6 +4,26 @@ using SwiftUI;
 
 namespace SwiftUITestShared
 {
+	public partial class StackedView : View
+	{
+		public TupleView<(ClickButton, Text)> Body =>
+			new TupleView<(ClickButton, Text)> ((
+				new ClickButton (),
+				new Text ("Bottom text")
+			));
+	}
+
+	public partial class ClickButton : View
+	{
+		State<(string, bool)> state = new State<(string, bool)> (("Please click this button:", true));
+		public TupleView<(Text, Button<Text>?)> Body =>
+			new TupleView<(Text, Button<Text>?)> ((
+				new Text (state.Value.Item1),
+				state.Value.Item2 ? new Button<Text> (() => state.Value = ("Thanks!", false), new Text ("Click me!")) : null
+				));
+	}
+
+	/*
 	public partial class ClickButton : View
 	{
 		State<int?> counter = new State<int?> (null);
@@ -25,4 +45,6 @@ namespace SwiftUITestShared
 			}
 		}
 	}
+	*/
+
 }

--- a/XamiOSSwiftUITest/AppDelegate.cs
+++ b/XamiOSSwiftUITest/AppDelegate.cs
@@ -24,7 +24,7 @@ namespace XamiOSSwiftUITest
         {
             Window = new UIWindow (UIScreen.MainScreen.Bounds);
 
-            Window.RootViewController = new UIHostingViewController (new ClickButton ());
+            Window.RootViewController = new UIHostingViewController (new StackedView ());
 
             Window.MakeKeyAndVisible ();
             return true;

--- a/XamiOSSwiftUITest/XamiOSSwiftUITest.csproj
+++ b/XamiOSSwiftUITest/XamiOSSwiftUITest.csproj
@@ -13,6 +13,8 @@
         <MtouchEnableSGenConc>true</MtouchEnableSGenConc>
         <MtouchHttpClientHandler>NSUrlSessionHandler</MtouchHttpClientHandler>
         <RestoreProjectStyle>PackageReference</RestoreProjectStyle>
+        <LangVersion>8.0</LangVersion>
+        <Nullable>enable</Nullable>
     </PropertyGroup>
     <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|iPhoneSimulator' ">
         <DebugSymbols>true</DebugSymbols>

--- a/src/SwiftUI/Mac/Color.cs
+++ b/src/SwiftUI/Mac/Color.cs
@@ -11,12 +11,13 @@ namespace SwiftUI
 		#region Constructors
 		public Color (NSColor color)
 		{
-			Data = CreateFromNSColor (color.Handle.ToPointer ());
+			opaqueData = CreateFromNSColor (color.Handle);
 		}
 
 		public Color (string name, NSBundle? bundle = null)
 		{
-			Data = CreateFromStringBundle (new Swift.String (name), bundle == null ? IntPtr.Zero.ToPointer () : bundle.Handle.ToPointer ());
+			using (var swiftName = new Swift.String (name))
+				opaqueData = CreateFromStringBundle (swiftName, bundle?.Handle ?? IntPtr.Zero);
 		}
 		#endregion
 
@@ -25,7 +26,7 @@ namespace SwiftUI
 		[DllImport(SwiftUILib.Path,
 			CallingConvention = CallingConvention.Cdecl,
 			EntryPoint = "$s7SwiftUI5ColorVyACSo7NSColorCcfC")]
-		static extern IntPtr CreateFromNSColor (void* colorPointer);
+		static extern IntPtr CreateFromNSColor (IntPtr colorPointer);
 
 
 		[DllImport (SwiftUILib.Path,
@@ -33,7 +34,7 @@ namespace SwiftUI
 			EntryPoint = "$s7SwiftUI5ColorV_6bundleACSS_So8NSBundleCSgtcfC")]
 		static extern IntPtr CreateFromStringBundle (
 			Swift.String str,
-			void* bundlePointer);
+			IntPtr bundlePointer);
         #endregion
     }
 }

--- a/src/SwiftUI/Swift/Interop/ISwiftValue.cs
+++ b/src/SwiftUI/Swift/Interop/ISwiftValue.cs
@@ -145,6 +145,7 @@ namespace Swift.Interop
 				ISwiftValue swiftValue => swiftValue.GetSwiftHandle (),
 				string val => new SwiftHandle (new Swift.String (val), swiftType, destroyOnDispose: true),
 				ITuple tup => GetTupleHandle (tup, swiftType, nullability),
+				bool val => new SwiftHandle (val? (byte)1 : (byte)0, swiftType), // FIXME: Don't box and pin a byte
 				_ when type.IsPrimitive => new SwiftHandle (obj, swiftType),
 				_ => throw new NotImplementedException (type.ToString ())
 			};
@@ -206,6 +207,9 @@ namespace Swift.Interop
 				var str = Marshal.PtrToStructure<Swift.String> (ptr);
 				// FIXME: lifetime?? Should we dispose this? Depends on where the ptr is coming from
 				return str.ToString ();
+
+			case TypeCode.Boolean:
+				return Marshal.ReadByte (ptr) == 1;
 			}
 
 			if (typeof (ITuple).IsAssignableFrom (ty))

--- a/src/SwiftUI/Swift/Interop/ManagedSwiftType.cs
+++ b/src/SwiftUI/Swift/Interop/ManagedSwiftType.cs
@@ -136,8 +136,7 @@ namespace Swift.Interop
 		{
 			foreach (var fldInfo in NativeFields) {
 				var fld = (ISwiftFieldExposable)fldInfo.Field.GetValue (instance);
-				fld.SetSwiftType (fldInfo.SwiftType, fldInfo.Nullability);
-				fld.InitNativeData ((byte*)data + fldInfo.Offset);
+				fld.InitNativeData ((byte*)data + fldInfo.Offset, fldInfo.Nullability);
 			}
 		}
 

--- a/src/SwiftUI/Swift/Interop/Nullability.cs
+++ b/src/SwiftUI/Swift/Interop/Nullability.cs
@@ -60,6 +60,9 @@ namespace Swift.Interop
 		public static Nullability Of (FieldInfo field)
 			=> Of (field.FieldType, GetAttributedNullability (field));
 
+		public static Nullability Of (PropertyInfo prop)
+			=> Of (prop.PropertyType, GetAttributedNullability (prop));
+
 		internal static Nullability Of (Type type, ReadOnlySpan<byte> attributedNullability = default)
 			=> Of (type, ref attributedNullability);
 
@@ -169,9 +172,8 @@ namespace Swift.Interop
 			return prop.GetValue (value);
 		}
 
-		public static TNullable Wrap<TNullable> (object? value)
+		public static object? Wrap (object? value, Type ty)
 		{
-			var ty = typeof (TNullable);
 			if (value == null && !ty.IsValueType)
 				return default!;
 			if (IsReifiedNullable (ty)) {
@@ -187,7 +189,7 @@ namespace Swift.Interop
 				if (!(transform is null))
 					value = transform.Invoke (null, new[] { value });
 			}
-			return (TNullable)value!;
+			return value;
 		}
 
 		/// <summary>

--- a/src/SwiftUI/Swift/Interop/SwiftStruct.cs
+++ b/src/SwiftUI/Swift/Interop/SwiftStruct.cs
@@ -8,18 +8,6 @@ namespace Swift.Interop
 	unsafe interface ISwiftFieldExposable : ISwiftValue
 	{
 		/// <summary>
-		/// Sets updated <see cref="SwiftType"/> and <see cref="Nullability"/> information.
-		/// </summary>
-		/// <remarks>
-		/// When exposed as a field, nullability information for reference types is
-		///  only available as attributes on the field. If it is to be nullable, the
-		///  <see cref="SwiftType"/> must be wrapped in a Swift Optional. Thus, this
-		///  method may be called to provide updated <see cref="SwiftType"/> and
-		///  <see cref="Nullability"/> information not available through <c>SwiftType.Of(GetType())</c>.
-		/// </remarks>
-		void SetSwiftType (SwiftType swiftType, Nullability nullability);
-
-		/// <summary>
 		/// Initializes the native data for this Swift type at the given location.
 		/// </summary>
 		void InitNativeData (void* handle);
@@ -50,9 +38,8 @@ namespace Swift.Interop
 	/// </remarks>
 	public unsafe abstract class SwiftStruct : ISwiftFieldExposable
 	{
-		SwiftType? swiftType;
-		protected SwiftType SwiftType
-			=> swiftType ??= SwiftType.Of (GetType ()) ?? throw new UnknownSwiftTypeException (GetType ());
+		protected virtual SwiftType SwiftType
+			=> SwiftType.Of (GetType ()) ?? throw new UnknownSwiftTypeException (GetType ());
 
 		// This is a tagged pointer that indicates whether we allocated the memory or not.
 		private protected TaggedPointer data;
@@ -73,25 +60,6 @@ namespace Swift.Interop
 				}
 			}
 			return new SwiftHandle (data.Pointer, SwiftType);
-		}
-
-		/// <summary>
-		/// Sets the nullability of this instance when used as a field.
-		/// </summary>
-		/// <remarks>
-		/// Nullability for reference types in C# is not reified in the type
-		///  system, but instead annotated with custom attributes at the declaration
-		///  site. This method is called when this instance is used as a field that
-		///  is exposed to Swift.
-		/// </remarks>
-		protected virtual void SetNullability (Nullability nullability)
-		{
-		}
-
-		void ISwiftFieldExposable.SetSwiftType (SwiftType swiftType, Nullability nullability)
-		{
-			this.swiftType = swiftType;
-			SetNullability (nullability);
 		}
 
 		void ISwiftFieldExposable.InitNativeData (void* handle)

--- a/src/SwiftUI/Swift/Interop/SwiftTupleType.cs
+++ b/src/SwiftUI/Swift/Interop/SwiftTupleType.cs
@@ -1,0 +1,70 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+
+namespace Swift.Interop
+{
+	using static SwiftCoreLib;
+
+	public unsafe class SwiftTupleType : SwiftType
+	{
+		readonly SwiftType [] elementTypes;
+
+		internal override int MangledTypeTrailingPointers
+			=> elementTypes.Sum (et => et.MangledTypeTrailingPointers);
+
+		internal override int MangledTypeSizeInner
+			=> elementTypes.Sum (et => et.MangledTypeSizeInner) + 2; // '_' (or 'y') and 't'
+
+		SwiftTupleType (SwiftType [] elementTypes, TypeMetadata** elts, ushort len)
+			: base (Lib, GetTupleType (0, new TupleTypeFlags (len), elts, null, null))
+		{
+			this.elementTypes = elementTypes ?? throw new ArgumentNullException (nameof (elementTypes));
+		}
+
+		public static SwiftType? Of (Type [] args, Nullability nullability = default)
+		{
+			var len = checked((ushort)args.Length);
+			switch (len) {
+			case 0:
+				return new SwiftType (Lib, "yt");
+			case 1:
+				// Swift just treats 1-ples as a single value
+				return Of (args [0], nullability [0]);
+			default:
+				var elems = new SwiftType [len];
+				var elts = stackalloc TypeMetadata* [len];
+				for (var i = 0; i < len; i++) {
+					var el = Of (args [i], nullability [i]);
+					if (el is null)
+						return null;
+					elems [i] = el;
+					elts [i] = el.Metadata;
+				}
+				return new SwiftTupleType (elems, elts, len);
+			}
+		}
+
+		internal override unsafe byte* WriteMangledType (byte* dest, void** tpBase, List<IntPtr> trailingPtrs)
+		{
+			switch (elementTypes.Length) {
+
+			case 0:
+				*dest = (byte)'y';
+				dest++;
+				break;
+			default:
+				dest = elementTypes [0].WriteMangledType (dest, tpBase, trailingPtrs);
+				*dest = (byte)'_';
+				dest++;
+				for (var i = 1; i < elementTypes.Length; i++)
+					dest = elementTypes [i].WriteMangledType (dest, tpBase, trailingPtrs);
+				break;
+			}
+			*dest = (byte)'t';
+			dest++;
+
+			return dest;
+		}
+	}
+}

--- a/src/SwiftUI/Swift/Interop/SwiftType.cs
+++ b/src/SwiftUI/Swift/Interop/SwiftType.cs
@@ -232,10 +232,9 @@ namespace Swift.Interop
 		/// </remarks>
 		//
 		// Sync with SwiftValue.ToSwiftValue
-		public static SwiftType? Of (Type type, Nullability? givenNullability = default)
+		public static SwiftType? Of (Type type, Nullability nullability = default)
 		{
 			SwiftType? result;
-			var nullability = givenNullability ?? Nullability.Of (type);
 			lock (registry) {
 				if (!registry.TryGetValue (type, out result)) {
 					// First see if it is a core type

--- a/src/SwiftUI/Swift/Interop/SwiftType.cs
+++ b/src/SwiftUI/Swift/Interop/SwiftType.cs
@@ -89,11 +89,11 @@ namespace Swift.Interop
 
 		internal IReadOnlyList<SwiftType>? GenericArguments => genericArgs;
 
-		internal int MangledTypeTrailingPointers =>
+		internal virtual int MangledTypeTrailingPointers =>
 			(mangledName is null ? 1 : 0) + (genericArgs?.Sum (ga => ga.MangledTypeTrailingPointers) ?? 0);
 
 		// size without null termination or trailing pointers
-		int MangledTypeSizeInner =>
+		internal virtual int MangledTypeSizeInner =>
 			(mangledName?.Length ?? sizeof (SymbolicReference)) +
 			(genericArgs?.Sum (ga => ga.MangledTypeSizeInner) + 2 ?? 0); // +2 for 'y' and 'G'
 
@@ -106,9 +106,11 @@ namespace Swift.Interop
 			IntPtr.Size * MangledTypeTrailingPointers + // FIXME: Make sure trailing ptrs are aligned?
 			1; // null terminated
 
-		byte* WriteMangledType (byte* dest, void** tpBase, List<IntPtr> trailingPtrs)
+		internal virtual byte* WriteMangledType (byte* dest, void** tpBase, List<IntPtr> trailingPtrs)
 		{
 			if (mangledName is null) {
+				// This codepath assumes it's a nominal type
+				Debug.Assert (Metadata->Kind.IsNominal ());
 				var symRef = (SymbolicReference*)dest;
 				symRef->Kind = SymbolicReferenceKind.IndirectContext;
 				symRef->Pointer.Target = tpBase + trailingPtrs.Count;
@@ -145,6 +147,7 @@ namespace Swift.Interop
 			*dest = 0; // null terminated
 			dest++;
 			Debug.Assert (dest == tpBase);
+			Debug.Assert (trailingPtrs.Count == MangledTypeTrailingPointers);
 
 			// Write trailing pointers
 			var ptr = (IntPtr)dest;
@@ -163,10 +166,16 @@ namespace Swift.Interop
 
 		// Using IntPtr typeMetadata arg here instead of FullTypeMetadata* so it's easier
 		//  to just pass the result of lib.RequireSymbol
-		public SwiftType (NativeLib? lib, IntPtr typeMetadata, Type? managedType = null, SwiftType []? genericArgs = null)
+		public SwiftType (NativeLib? lib,
+			IntPtr typeMetadata,
+			string? mangledName = null,
+			Type? managedType = null,
+			SwiftType []? genericArgs = null)
 		{
 			this.lib = lib;
 			this.fullMetadata = (FullTypeMetadata*)(typeMetadata - IntPtr.Size);
+			if (!(mangledName is null))
+				this.mangledName = NormalizeMangledName (mangledName);
 			this.genericArgs = genericArgs;
 
 			// Assert assumed invariants..
@@ -180,8 +189,9 @@ namespace Swift.Interop
 			if (managedType is null)
 				return;
 			checked {
-				Debug.Assert (Metadata->TypeDescriptor->Name == GetSwiftTypeName (managedType), $"unexpected name: {Metadata->TypeDescriptor->Name}");
 				Debug.Assert (Metadata->Kind == MetadataKind.OfType (managedType), $"unexpected kind: {Metadata->Kind}");
+				if (Metadata->Kind.IsNominal ())
+					Debug.Assert (Metadata->TypeDescriptor->Name == GetSwiftTypeName (managedType), $"unexpected name: {Metadata->TypeDescriptor->Name}");
 				Debug.Assert (!managedType.IsValueType || (int)ValueWitnessTable->Size == Marshal.SizeOf (managedType), $"unexpected size: {ValueWitnessTable->Size}");
 				// We should think hard before making a non-POD Swift struct a public C# struct
 				//  (Swift.String is internal and we are careful to manage its lifetime)
@@ -194,9 +204,8 @@ namespace Swift.Interop
 		/// </summary>
 		/// <param name="mangledName">The mangled name of the Swift type.</param>
 		public SwiftType (NativeLib lib, string mangledName, Type? managedType = null)
-			: this (lib, lib.RequireSymbol ("$s" + NormalizeMangledName (mangledName) + "N"), managedType)
+			: this (lib, lib.RequireSymbol ("$s" + NormalizeMangledName (mangledName) + "N"), mangledName, managedType)
 		{
-			this.mangledName = NormalizeMangledName (mangledName);
 		}
 
 		/// <summary>
@@ -262,7 +271,7 @@ namespace Swift.Interop
 						// FIXME: Treat F# Unit as 0-element tuple?
 						if (typeof (ITuple).IsAssignableFrom (type)) {
 							var args = type.GetGenericArguments ();
-							result = SwiftCoreLib.GetTupleType (args, nullability);
+							result = SwiftTupleType.Of (args, nullability);
 						}
 
 						// If it's a nullable type, try to unwrap it

--- a/src/SwiftUI/Swift/Interop/SwiftTypeAttribute.cs
+++ b/src/SwiftUI/Swift/Interop/SwiftTypeAttribute.cs
@@ -77,7 +77,7 @@ namespace Swift.Interop
 					}
 				}
 				var del = MetadataReq.MakeDelegate (args.Count - 1, ftnPtr);
-				return new SwiftType (lib, (IntPtr)del.DynamicInvoke (args.ToArray ()), genericArgs: typeArgs);
+				return new SwiftType (lib, (IntPtr)del.DynamicInvoke (args.ToArray ()), attributedType, typeArgs);
 			}
 		}
 	}

--- a/src/SwiftUI/Swift/Interop/SwiftTypeAttribute.cs
+++ b/src/SwiftUI/Swift/Interop/SwiftTypeAttribute.cs
@@ -17,11 +17,12 @@ namespace Swift.Interop
 		/// <param name="attributedType">The <see cref="Type"/> that is attributed by this instance.</param>
 		/// <param name="typeArgs">The <see cref="SwiftType"/> for each generic argument or element type,
 		///  or <c>null</c> if this type has no generic arguments or element types.</param>
-		/// <remarks>
+		/// <returns>the <see cref="SwiftType"/> for the given attributed managed type, or <c>null</c>.</returns>
+		/// <remarks>	
 		/// This method should only be called by <see cref="SwiftType.Of(Type)"/>.
 		///  Do not call this this method directly.
 		/// </remarks>
-		protected internal abstract SwiftType GetSwiftType (Type attributedType, SwiftType []? typeArgs);
+		protected internal abstract SwiftType? GetSwiftType (Type attributedType, SwiftType []? typeArgs);
 	}
 
 	/// <summary>

--- a/src/SwiftUI/Swift/Interop/SwiftTypeAttribute.cs
+++ b/src/SwiftUI/Swift/Interop/SwiftTypeAttribute.cs
@@ -77,7 +77,7 @@ namespace Swift.Interop
 					}
 				}
 				var del = MetadataReq.MakeDelegate (args.Count - 1, ftnPtr);
-				return new SwiftType (lib, (IntPtr)del.DynamicInvoke (args.ToArray ()), attributedType, typeArgs);
+				return new SwiftType (lib, (IntPtr)del.DynamicInvoke (args.ToArray ()), null, attributedType, typeArgs);
 			}
 		}
 	}

--- a/src/SwiftUI/Swift/Interop/TupleTypeFlags.cs
+++ b/src/SwiftUI/Swift/Interop/TupleTypeFlags.cs
@@ -1,0 +1,17 @@
+using System;
+using System.Runtime.InteropServices;
+
+namespace Swift.Interop
+{
+	//https://github.com/apple/swift/blob/a021e6ca020e667ce4bc8ee174e2de1cc0d9be73/include/swift/ABI/MetadataValues.h#L948
+	[StructLayout (LayoutKind.Sequential)]
+	readonly struct TupleTypeFlags
+	{
+		readonly ulong/*size_t*/ data;
+
+		public TupleTypeFlags (ushort numElements)
+		{
+			data = numElements;
+		}
+	}
+}

--- a/src/SwiftUI/Swift/Interop/TypeMetadata.cs
+++ b/src/SwiftUI/Swift/Interop/TypeMetadata.cs
@@ -71,6 +71,13 @@ namespace Swift.Interop
 	}
 
 	[StructLayout (LayoutKind.Sequential)]
+	public unsafe struct FullTypeMetadata
+	{
+		public ValueWitnessTable* ValueWitnessTable;
+		public TypeMetadata Metadata;
+	}
+
+	[StructLayout (LayoutKind.Sequential)]
 	public unsafe struct TypeMetadata
 	{
 		public MetadataKinds Kind;
@@ -89,10 +96,21 @@ namespace Swift.Interop
 #endif
 	}
 
+	//https://github.com/apple/swift/blob/db4ce1f01bbb1ecda5fe744905a7fe61b3ff5a25/include/swift/ABI/Metadata.h#L1475
 	[StructLayout (LayoutKind.Sequential)]
-	public unsafe struct FullTypeMetadata
+	public unsafe struct TupleTypeMetadata
 	{
-		public ValueWitnessTable* ValueWitnessTable;
-		public TypeMetadata Metadata;
+		public MetadataKinds Kind;
+		/// The number of elements.
+		public ulong NumElements;
+		public IntPtr Labels;
+
+		// ... followed by NumElements * Element...
+		[StructLayout (LayoutKind.Sequential)]
+		public struct Element
+		{
+			public TypeMetadata* Type;
+			public ulong Offset;
+		}
 	}
 }

--- a/src/SwiftUI/Swift/Interop/TypeMetadata.cs
+++ b/src/SwiftUI/Swift/Interop/TypeMetadata.cs
@@ -58,6 +58,15 @@ namespace Swift.Interop
 
 	public static class MetadataKind
 	{
+		public static bool IsNominal (this MetadataKinds kind) => kind switch
+		{
+			MetadataKinds.Struct   => true,
+			MetadataKinds.Enum     => true,
+			MetadataKinds.Optional => true,
+			_ when kind.IsClass () => true,
+			_ => false
+		};
+
 		public static bool IsClass (this MetadataKinds kind)
 			=> kind == MetadataKinds.Class || (long)kind > 2047;
 
@@ -81,6 +90,8 @@ namespace Swift.Interop
 	public unsafe struct TypeMetadata
 	{
 		public MetadataKinds Kind;
+
+		// Only valid if the type is nominal
 		public NominalTypeDescriptor* TypeDescriptor;
 
 #if DEBUG_TOSTRING
@@ -89,7 +100,7 @@ namespace Swift.Interop
 			var str = Kind.ToString ();
 			if (Kind == MetadataKinds.Struct)
 				str += ((StructDescriptor*)TypeDescriptor)->ToString ();
-			else
+			else if (Kind.IsNominal ())
 				str += TypeDescriptor->ToString ();
 			return str;
 		}

--- a/src/SwiftUI/Swift/Optional.cs
+++ b/src/SwiftUI/Swift/Optional.cs
@@ -66,6 +66,9 @@ namespace Swift
 
 			Packed (T value) => this.value = value;
 
+			public static implicit operator Packed<T> (T? value)
+				=> value.HasValue? Some (value.Value) : None;
+
 			#if DEBUG
 			static Packed ()
 			{
@@ -115,13 +118,16 @@ namespace Swift
 				this.extraBits = 0;
 			}
 
+			public static implicit operator Unpacked<T> (T? value)
+				=> value.HasValue? Some (value.Value) : None;
+
 			#if DEBUG
 			static Unpacked ()
 			{
 				unsafe {
 					Debug.Assert (!UnderlyingSwiftType.ValueWitnessTable->HasExtraInhabitants,
 						$"Type {nameof (T)} has extra inhabitants; use {nameof (Packed<T>)} instead");
-					Debug.Assert ((int)SwiftType.Of (typeof (T), new Nullability (true))!.ValueWitnessTable->Size == Marshal.SizeOf<T> () + 1); // FIXME
+					Debug.Assert ((int)SwiftType.Of (typeof (T), new Nullability (true))!.ValueWitnessTable->Size == Marshal.SizeOf<T> () + 1);
 				}
 			}
 			#endif

--- a/src/SwiftUI/SwiftUI/HorizontalAlignment.cs
+++ b/src/SwiftUI/SwiftUI/HorizontalAlignment.cs
@@ -1,0 +1,35 @@
+﻿using System;
+using System.Runtime.InteropServices;
+
+using Swift.Interop;
+
+namespace SwiftUI
+{
+	[SwiftImport (SwiftUILib.Path)]
+	[StructLayout (LayoutKind.Sequential)]
+	public readonly struct HorizontalAlignment : ISwiftBlittableStruct<HorizontalAlignment>
+	{
+		readonly IntPtr opaqueData;
+
+		public static extern HorizontalAlignment Leading {
+			[DllImport (SwiftUILib.Path,
+				CallingConvention = CallingConvention.Cdecl,
+				EntryPoint = "$s7SwiftUI19HorizontalAlignmentV7leadingACvgZ")]
+			get;
+		}
+
+		public static extern HorizontalAlignment Center {
+			[DllImport (SwiftUILib.Path,
+				CallingConvention = CallingConvention.Cdecl,
+				EntryPoint = "$s7SwiftUI19HorizontalAlignmentV6centerACvgZ")]
+			get;
+		}
+
+		public static extern HorizontalAlignment Trailing {
+			[DllImport (SwiftUILib.Path,
+				CallingConvention = CallingConvention.Cdecl,
+				EntryPoint = "$s7SwiftUI19HorizontalAlignmentV8trailingACvgZ")]
+			get;
+		}
+	}
+}

--- a/src/SwiftUI/SwiftUI/Interop/CustomViewType.cs
+++ b/src/SwiftUI/SwiftUI/Interop/CustomViewType.cs
@@ -31,19 +31,12 @@ namespace SwiftUI.Interop
 	unsafe class CustomViewType : ManagedSwiftType
 	{
 		ViewProtocolConformanceDescriptor* viewConformanceDesc;
-		ProtocolWitnessTable* viewConformance;
 
 		public override int NativeFieldsOffset => sizeof (CustomViewData);
 
 		public override uint AdditionalMetadataPointers => CustomViewMetadata.AdditionalPointers;
 
-		public ProtocolWitnessTable* ViewConformance {
-			get {
-				if (viewConformance == null)
-					viewConformance = CreateViewConformance ();
-				return viewConformance;
-			}
-		}
+		public ProtocolWitnessTable* ViewConformance { get; }
 
 		public PropertyInfo BodyProperty { get; }
 
@@ -62,6 +55,11 @@ namespace SwiftUI.Interop
 				// Currently unused, so don't force allocation if it's a custom view
 				//thunkMetadata->ThunkViewTViewConformance = swiftBodyType.ViewConformance;
 				thunkMetadata->ThunkViewTViewConformance = null;
+
+				// Proactively create View conformance. While generics that are explicitly constrained to View
+				//  have the conformance passed in, other cases, such as TupleView, look up the conformance
+				//  dynamically, so it's important to register it eagerly.
+				ViewConformance = CreateViewConformance ();
 			} catch {
 				// Ensure we don't leak allocated unmanaged memory
 				Dispose (true);

--- a/src/SwiftUI/SwiftUI/State.cs
+++ b/src/SwiftUI/SwiftUI/State.cs
@@ -11,38 +11,30 @@ namespace SwiftUI
 	using static State;
 
 	[SwiftImport (SwiftUILib.Path)]
-	public sealed class State<TValue> : SwiftStruct, ISwiftValue
+	public sealed class State<TValue> : SwiftStruct
 	{
 		TValue initialValue;
 
-		SwiftType? swiftType, valueType;
+		SwiftType? valueType;
 		Nullability valueNullability;
-
-		protected override SwiftType SwiftType => swiftType ??= base.SwiftType;
-		SwiftType ValueType
-			=> valueType ??= SwiftType.Of (typeof (TValue), valueNullability) ?? throw new UnknownSwiftTypeException (typeof (TValue));
 
 		public unsafe TValue Value {
 			get {
-				// Don't force premature initialization- in the common case we're in a custom view,
-				//  it will init us when it's ready..
 				if (!NativeDataInitialized)
 					return initialValue;
 
 				// Allocate memory for the value
-				var ptr = Marshal.AllocHGlobal (ValueType.NativeDataSize);
+				var ptr = Marshal.AllocHGlobal (valueType!.NativeDataSize);
 				try {
 					// FIXME: Results in 2 copies- can we do better?
 					using (var handle = GetSwiftHandle ())
-						GetWrappedValue ((void*)ptr, handle.Pointer, ValueType.Metadata);
+						GetWrappedValue ((void*)ptr, handle.Pointer, valueType.Metadata);
 					return (TValue)SwiftValue.FromNative (ptr, typeof (TValue), valueNullability)!;
 				} finally {
 					Marshal.FreeHGlobal (ptr);
 				}
 			}
 			set {
-				// Don't force premature initialization- in the common case we're in a custom view,
-				//  it will init us when it's ready..
 				if (!NativeDataInitialized) {
 					initialValue = value;
 					return;
@@ -59,17 +51,13 @@ namespace SwiftUI
 			this.initialValue = initialValue;
 		}
 
-		void ISwiftValue.SetSwiftType (SwiftType swiftType, Nullability nullability)
+		protected override unsafe void InitNativeData (void* handle, Nullability nullability)
 		{
-			Debug.Assert (valueType == null);
-			this.swiftType = swiftType;
-			this.valueNullability = nullability [0];
-		}
-
-		protected override unsafe void InitNativeData (void* handle)
-		{
-			using (var value = initialValue.GetSwiftHandle (valueNullability))
-				Init (handle, value.Pointer, value.SwiftType.Metadata);
+			valueNullability = nullability [0];
+			using (var value = initialValue.GetSwiftHandle (valueNullability)) {
+				valueType = value.SwiftType;
+				Init (handle, value.Pointer, valueType.Metadata);
+			}
 		}
 	}
 

--- a/src/SwiftUI/SwiftUI/View.cs
+++ b/src/SwiftUI/SwiftUI/View.cs
@@ -82,7 +82,7 @@ namespace SwiftUI
 
 		protected override void InitNativeData (void* handle, Nullability nullability)
 		{
-			var cvt = SwiftType.Of (GetType (), nullability) as CustomViewType;
+			var cvt = swiftType as CustomViewType;
 			Debug.Assert (cvt != null, "View bindings must override InitNativeData and not call base");
 
 			// First alloc a weak GCHandle, since we don't know if native code will

--- a/src/SwiftUI/SwiftUI/Views/Button.cs
+++ b/src/SwiftUI/SwiftUI/Views/Button.cs
@@ -20,10 +20,10 @@ namespace SwiftUI
 			this.label = label ?? throw new ArgumentNullException (nameof (label));
 		}
 
-		protected override unsafe void InitNativeData (void* handle)
+		protected override unsafe void InitNativeData (void* handle, Nullability nullability)
 		{
 			var ctx = GCHandle.ToIntPtr (GCHandle.Alloc (action));
-			using (var lbl = label.GetSwiftHandle ()) {
+			using (var lbl = label.GetSwiftHandle (nullability [0])) {
 				var lty = lbl.SwiftType;
 				Init (handle, OnActionDel, OnDisposeDel, ctx, lbl.Pointer, lty.Metadata, lty.GetProtocolConformance (SwiftUILib.ViewProtocol));
 			}

--- a/src/SwiftUI/SwiftUI/Views/EmptyView.cs
+++ b/src/SwiftUI/SwiftUI/Views/EmptyView.cs
@@ -4,7 +4,7 @@ using Swift.Interop;
 namespace SwiftUI
 {
 	[SwiftImport (SwiftUILib.Path)]
-	public class EmptyView : View
+	public sealed class EmptyView : View
 	{
 		protected override unsafe void InitNativeData (void* handle)
 		{

--- a/src/SwiftUI/SwiftUI/Views/EmptyView.cs
+++ b/src/SwiftUI/SwiftUI/Views/EmptyView.cs
@@ -6,7 +6,7 @@ namespace SwiftUI
 	[SwiftImport (SwiftUILib.Path)]
 	public sealed class EmptyView : View
 	{
-		protected override unsafe void InitNativeData (void* handle)
+		protected override unsafe void InitNativeData (void* handle, Nullability nullability)
 		{
 		}
 	}

--- a/src/SwiftUI/SwiftUI/Views/Text.cs
+++ b/src/SwiftUI/SwiftUI/Views/Text.cs
@@ -16,7 +16,7 @@ namespace SwiftUI
 			this.verbatim = verbatim;
 		}
 
-		protected override void InitNativeData (void* handle)
+		protected override void InitNativeData (void* handle, Nullability nullability)
 		{
 			using (var str = new Swift.String (verbatim))
 				Init (handle, str);

--- a/src/SwiftUI/SwiftUI/Views/TupleView.cs
+++ b/src/SwiftUI/SwiftUI/Views/TupleView.cs
@@ -15,26 +15,15 @@ namespace SwiftUI
 	{
 		readonly TTuple value;
 
-		SwiftType? swiftType;
-		Nullability valueNullability;
-
-		protected override SwiftType SwiftType => swiftType ??= base.SwiftType;
-
 		public TupleView (TTuple value)
 		{
 			this.value = value;
 		}
 
-		protected override unsafe void InitNativeData (void* handle)
+		protected override unsafe void InitNativeData (void* handle, Nullability nullability)
 		{
-			using (var val = value.GetSwiftHandle (valueNullability))
+			using (var val = value.GetSwiftHandle (nullability [0]))
 				Init (handle, val.Pointer, val.SwiftType.Metadata);
-		}
-
-		void ISwiftValue.SetSwiftType (SwiftType swiftType, Nullability nullability)
-		{
-			this.swiftType = swiftType;
-			this.valueNullability = nullability [0];
 		}
 	}
 

--- a/src/SwiftUI/SwiftUI/Views/TupleView.cs
+++ b/src/SwiftUI/SwiftUI/Views/TupleView.cs
@@ -10,10 +10,15 @@ namespace SwiftUI
 	using static TupleView;
 
 	[SwiftImport (SwiftUILib.Path)]
-	public sealed class TupleView<TTuple> : View
+	public sealed class TupleView<TTuple> : View, ISwiftValue
 		where TTuple : ITuple
 	{
 		readonly TTuple value;
+
+		SwiftType? swiftType;
+		Nullability valueNullability;
+
+		protected override SwiftType SwiftType => swiftType ??= base.SwiftType;
 
 		public TupleView (TTuple value)
 		{
@@ -22,8 +27,14 @@ namespace SwiftUI
 
 		protected override unsafe void InitNativeData (void* handle)
 		{
-			using (var val = value.GetSwiftHandle ())
+			using (var val = value.GetSwiftHandle (valueNullability))
 				Init (handle, val.Pointer, val.SwiftType.Metadata);
+		}
+
+		void ISwiftValue.SetSwiftType (SwiftType swiftType, Nullability nullability)
+		{
+			this.swiftType = swiftType;
+			this.valueNullability = nullability [0];
 		}
 	}
 

--- a/src/SwiftUI/SwiftUI/Views/TupleView.cs
+++ b/src/SwiftUI/SwiftUI/Views/TupleView.cs
@@ -1,0 +1,37 @@
+using System;
+using System.Runtime.InteropServices;
+using System.Runtime.CompilerServices;
+
+using Swift;
+using Swift.Interop;
+
+namespace SwiftUI
+{
+	using static TupleView;
+
+	[SwiftImport (SwiftUILib.Path)]
+	public sealed class TupleView<TTuple> : View
+		where TTuple : ITuple
+	{
+		readonly TTuple value;
+
+		public TupleView (TTuple value)
+		{
+			this.value = value;
+		}
+
+		protected override unsafe void InitNativeData (void* handle)
+		{
+			using (var val = value.GetSwiftHandle ())
+				Init (handle, val.Pointer, val.SwiftType.Metadata);
+		}
+	}
+
+	unsafe static class TupleView
+	{
+		[DllImport (SwiftGlueLib.Path,
+			CallingConvention = CallingConvention.Cdecl,
+			EntryPoint = "swiftui_TupleView_value")]
+		internal static extern void Init (void* result, void* valuePtr, TypeMetadata* valueMetadata);
+	}
+}

--- a/src/SwiftUI/SwiftUI/Views/VStack.cs
+++ b/src/SwiftUI/SwiftUI/Views/VStack.cs
@@ -1,0 +1,53 @@
+﻿using System;
+using System.Runtime.InteropServices;
+
+using Swift;
+using Swift.Interop;
+
+namespace SwiftUI
+{
+	using static VStack;
+
+	[SwiftImport (SwiftUILib.Path)]
+	public sealed class VStack<TContent> : View where TContent : View
+	{
+		readonly HorizontalAlignment alignment;
+		readonly double? spacing;
+		readonly TContent content;
+
+		public VStack (TContent content)
+			// FIXME: Call the functions to get the default values from SwiftUI
+			: this (HorizontalAlignment.Center, null, content)
+		{
+		}
+
+		public VStack (HorizontalAlignment alignment, TContent content)
+			// FIXME: Call the functions to get the default values from SwiftUI
+			: this (alignment, null, content)
+		{
+		}
+
+		public VStack (HorizontalAlignment alignment, double? spacing, TContent content)
+		{
+			this.alignment = alignment;
+			this.spacing = spacing;
+			this.content = content;
+		}
+
+		protected override unsafe void InitNativeData (void* handle, Nullability nullability)
+		{
+			using (var ctnt = content.GetSwiftHandle (nullability [0])) {
+				var cty = ctnt.SwiftType;
+				Init (handle, alignment, spacing.HasValue, spacing ?? 0, ctnt.Pointer, cty.Metadata, cty.GetProtocolConformance (SwiftUILib.ViewProtocol));
+			}
+		}
+	}
+
+	unsafe static class VStack
+	{
+		[DllImport (SwiftGlueLib.Path,
+			CallingConvention = CallingConvention.Cdecl,
+			EntryPoint = "swiftui_VStack_align_spacing_content")]
+		internal static extern void Init (void* result, HorizontalAlignment align, bool spacingHasValue, double spacing, void* contentData, TypeMetadata* contentType, ProtocolWitnessTable* contentViewConformance);
+	}
+}

--- a/src/SwiftUI/iOS/Color.cs
+++ b/src/SwiftUI/iOS/Color.cs
@@ -13,12 +13,13 @@ namespace SwiftUI
 		#region Constructors
 		public Color (UIColor color)
 		{
-			Data = CreateFromUIColor(color.Handle.ToPointer());
+			opaqueData = CreateFromUIColor (color.Handle);
 		}
 
 		public Color (string name, NSBundle? bundle = null)
 		{
-			Data = CreateFromStringBundle (new Swift.String (name), bundle == null ? IntPtr.Zero.ToPointer() : bundle.Handle.ToPointer());
+			using (var swiftName = new Swift.String (name))
+				opaqueData = CreateFromStringBundle (swiftName, bundle?.Handle ?? IntPtr.Zero);
 		}
 		#endregion
 
@@ -27,7 +28,7 @@ namespace SwiftUI
 		[DllImport (SwiftUILib.Path,
 			CallingConvention = CallingConvention.Cdecl,
 			EntryPoint = "$s7SwiftUI5ColorVyACSo7UIColorCcfC")]
-		static extern IntPtr CreateFromUIColor (void* colorPointer);
+		static extern IntPtr CreateFromUIColor (IntPtr colorPointer);
 
 		// Initialisations
 		[DllImport(SwiftUILib.Path,
@@ -35,7 +36,7 @@ namespace SwiftUI
 			EntryPoint = "$s7SwiftUI5ColorV_6bundleACSS_So8NSBundleCSgtcfC")]
 		static extern IntPtr CreateFromStringBundle (
 			Swift.String str,
-			void* bundlePointer);
+			IntPtr bundlePointer);
 		#endregion
 	}
 }

--- a/src/SwiftUIGlue/Glue.swift
+++ b/src/SwiftUIGlue/Glue.swift
@@ -89,6 +89,15 @@ public func State_wrappedValue_getter<T>(dest : UnsafeMutablePointer<T>, state :
 }
 
 //
+// Indirectly returned struct: return pointer is passed in rax.
+//
+@_silgen_name("swiftui_TupleView_value")
+public func TupleView_value<T>(dest : UnsafeMutablePointer<TupleView<T>>, value : T)
+{
+	dest.initialize(to: TupleView(value))
+}
+
+//
 // Class methods: Context register is used for pointer to type metadata
 //
 #if os(iOS) || os(tvOS)

--- a/src/SwiftUIGlue/Glue.swift
+++ b/src/SwiftUIGlue/Glue.swift
@@ -98,6 +98,16 @@ public func TupleView_value<T>(dest : UnsafeMutablePointer<TupleView<T>>, value 
 }
 
 //
+// Indirectly returned struct: return pointer is passed in rax.
+// Calling convention differs for CGFloat?
+//
+@_silgen_name("swiftui_VStack_align_spacing_content")
+public func VStack_align_spacing_content<T: View>(dest : UnsafeMutablePointer<VStack<T>>, align : HorizontalAlignment, spacingHasValue : Bool, spacing : CGFloat, content : T)
+{
+	dest.initialize(to: VStack(alignment: align, spacing: spacingHasValue ? spacing :  nil) { content })
+}
+
+//
 // Class methods: Context register is used for pointer to type metadata
 //
 #if os(iOS) || os(tvOS)
@@ -148,6 +158,9 @@ public func SetBodyFn(value : @escaping BodyFn)
     bodyFn = value
 }
 
+//
+// Indirectly returned struct: return pointer is passed in rax.
+//
 @_silgen_name("swiftui_View_opacity")
 public func SetViewOpacity<T: View>(dest : UnsafeMutableRawPointer, view : T, value : Double)
 {
@@ -155,6 +168,9 @@ public func SetViewOpacity<T: View>(dest : UnsafeMutableRawPointer, view : T, va
     dest.initializeMemory(as: type(of: result), repeating: result, count: 1)
 }
 
+//
+// Indirectly returned struct: return pointer is passed in rax.
+//
 @_silgen_name("swiftui_View_background")
 public func SetViewBackground<TView: View, TBackground: View>(dest : UnsafeMutableRawPointer, view : TView, value : TBackground)
 {

--- a/tests/SwiftUI.Tests.FSharp/TypeTests.fs
+++ b/tests/SwiftUI.Tests.FSharp/TypeTests.fs
@@ -27,12 +27,14 @@ let ``Nullability.IsNull`` () =
     Assert.False (Nullability.IsNull (ValueSome null))
 
 #nowarn "9" // unverifiable code
-let assertRoundtrip v =
+let assertRoundtrip (v : 'a) =
     use hnd = v.GetSwiftHandle()
-    hnd.Pointer
-    |> NativePtr.ofVoidPtr<int>
-    |> NativePtr.toNativeInt
-    |> SwiftValue.FromNative
+    let ptr =
+        hnd.Pointer
+        |> NativePtr.ofVoidPtr<int>
+        |> NativePtr.toNativeInt
+    SwiftValue.FromNative(ptr, typeof<'a>)
+    |> unbox
     |> (=) v
     |> Assert.True
 

--- a/tests/SwiftUI.Tests/TypeTests.cs
+++ b/tests/SwiftUI.Tests/TypeTests.cs
@@ -73,6 +73,8 @@ namespace SwiftUI.Tests
 		[InlineData (typeof (Optional.Unpacked<>), typeof (sbyte))]
 		[InlineData (typeof (Optional.Unpacked<>), typeof (int))]
 		[InlineData (typeof (Optional.Unpacked<>), typeof (long))]
+		// NOTE: For Double? we seem to match the in-memory representation, but the
+		//  calling convention differs.
 		[InlineData (typeof (Optional.Unpacked<>), typeof (double))]
 		[InlineData (typeof (Optional.Unpacked<>), typeof (float))]
 		public void OptionalTypes (Type optionalType, Type wrappedType)

--- a/tests/SwiftUI.Tests/TypeTests.cs
+++ b/tests/SwiftUI.Tests/TypeTests.cs
@@ -2,6 +2,7 @@ using System;
 using System.Linq;
 using System.Reflection;
 using System.Diagnostics;
+using System.Runtime.CompilerServices;
 
 using Xunit;
 
@@ -15,6 +16,23 @@ namespace SwiftUI.Tests
 {
 	public class TypeTests : TestFixture
 	{
+		static Type GetTypeForTest (Type ty)
+		{
+			if (!ty.IsGenericTypeDefinition)
+				return ty;
+
+			var gargs = ty.GetGenericArguments ();
+			for (var i = 0; i < gargs.Length; i++) {
+				var constr = gargs [i].GetGenericParameterConstraints ().SingleOrDefault ();
+				if (constr == typeof (ITuple))
+					gargs [i] = typeof (ValueTuple<Text,Text>);
+				else
+					gargs [i] = typeof (Text);
+			}
+
+			return ty.MakeGenericType (gargs);
+		}
+
 		[Fact]
 		public void AllSwiftTypesCanBeCreated ()
 		{
@@ -22,7 +40,7 @@ namespace SwiftUI.Tests
 				.Assembly
 				.GetTypes ()
 				.Where (ty => !ty.IsAbstract && Attribute.IsDefined (ty, typeof (SwiftTypeAttribute), true))
-				.Select (ty => ty.IsGenericTypeDefinition? ty.MakeGenericType (Array.ConvertAll (ty.GetGenericArguments (), _ => typeof (Text))) : ty);
+				.Select (GetTypeForTest);
 			Assert.All (types, ty => Assert.NotNull (SwiftType.Of (ty)));
 		}
 


### PR DESCRIPTION
This also includes a rework of the way nullability is flowed through the system and enables proper nullability for View.Body return type.

There is still an intermittent crash when you close the window of the Mac test app. Not clear what is causing it. It may be related to the ref counting of views.