### PR TITLE
Add samples back to solution and switch to project references

### DIFF
--- a/Xamarin.SwiftUI.sln
+++ b/Xamarin.SwiftUI.sln
@@ -18,6 +18,8 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Samples", "Samples", "{0A30
 EndProject
 Project("{F2A71F9B-5D33-465A-A702-920D77279786}") = "SwiftUI.FSharp", "src\SwiftUI.FSharp\SwiftUI.FSharp.fsproj", "{01AABDE7-D7FE-4C2F-9C28-2E316A72A6F0}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Samples", "samples\C#\Samples.csproj", "{43B437BA-4704-45BC-8598-F46E2E1FBA30}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -100,6 +102,18 @@ Global
 		{01AABDE7-D7FE-4C2F-9C28-2E316A72A6F0}.Release|iPhoneSimulator.Build.0 = Release|Any CPU
 		{01AABDE7-D7FE-4C2F-9C28-2E316A72A6F0}.Debug|iPhone.ActiveCfg = Debug|Any CPU
 		{01AABDE7-D7FE-4C2F-9C28-2E316A72A6F0}.Debug|iPhone.Build.0 = Debug|Any CPU
+		{43B437BA-4704-45BC-8598-F46E2E1FBA30}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{43B437BA-4704-45BC-8598-F46E2E1FBA30}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{43B437BA-4704-45BC-8598-F46E2E1FBA30}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{43B437BA-4704-45BC-8598-F46E2E1FBA30}.Release|Any CPU.Build.0 = Release|Any CPU
+		{43B437BA-4704-45BC-8598-F46E2E1FBA30}.Debug|iPhoneSimulator.ActiveCfg = Debug|Any CPU
+		{43B437BA-4704-45BC-8598-F46E2E1FBA30}.Debug|iPhoneSimulator.Build.0 = Debug|Any CPU
+		{43B437BA-4704-45BC-8598-F46E2E1FBA30}.Release|iPhone.ActiveCfg = Release|Any CPU
+		{43B437BA-4704-45BC-8598-F46E2E1FBA30}.Release|iPhone.Build.0 = Release|Any CPU
+		{43B437BA-4704-45BC-8598-F46E2E1FBA30}.Release|iPhoneSimulator.ActiveCfg = Release|Any CPU
+		{43B437BA-4704-45BC-8598-F46E2E1FBA30}.Release|iPhoneSimulator.Build.0 = Release|Any CPU
+		{43B437BA-4704-45BC-8598-F46E2E1FBA30}.Debug|iPhone.ActiveCfg = Debug|Any CPU
+		{43B437BA-4704-45BC-8598-F46E2E1FBA30}.Debug|iPhone.Build.0 = Debug|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -111,5 +125,6 @@ Global
 		{CCA6EDBD-0F63-4C2C-95E8-FEDBFA9BD0ED} = {96D409C9-7355-4EAA-8091-14802423E32E}
 		{28883268-FEE9-48E7-90A2-FDCED575CDE2} = {96D409C9-7355-4EAA-8091-14802423E32E}
 		{D9211517-73D3-4548-B5DA-CAFB0A5B74A5} = {96D409C9-7355-4EAA-8091-14802423E32E}
+		{43B437BA-4704-45BC-8598-F46E2E1FBA30} = {0A30EAB4-9484-4C3D-B7AF-3FF29EF250EC}
 	EndGlobalSection
 EndGlobal

--- a/samples/C#/Samples.csproj
+++ b/samples/C#/Samples.csproj
@@ -1,15 +1,17 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
-  <Import Project="../../LocalArtifacts.props" />
-
   <PropertyGroup>
     <OutputType>Exe</OutputType>
     <TargetFramework>net6.0-macos</TargetFramework>
     <SupportedOSPlatformVersion>10.15</SupportedOSPlatformVersion>
     <RuntimeIdentifiers>osx-arm64;osx-x64</RuntimeIdentifiers>
   </PropertyGroup>
-
   <ItemGroup>
     <None Include="Info.plist" />
-    <PackageReference Include="SwiftUI.NET" Version="$(Version)" />
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\..\src\SwiftUI\SwiftUI.csproj" />
+    <ProjectReference Include="..\..\src\SwiftUI.Analyzers\SwiftUI.Analyzers.csproj" PrivateAssets="all"
+                      ReferenceOutputAssembly="false"
+                      OutputItemType="Analyzer"/>
   </ItemGroup>
 </Project>


### PR DESCRIPTION
This will be easier to develop against than the package reference.

I'm getting an error from `lipo` when building this locally, but that might be due to my old Xcode version.

@CartBlanche Feel free to push to here if you have other changes locally that you think would help the development experience.